### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.6.4",
         "illuminate/support": "~5.4",
         "guzzlehttp/guzzle": "~6.0",
-        "laravel/socialite" : "~3.0"
+        "laravel/socialite" : "~4.0"
     },
     
     "require-dev": {


### PR DESCRIPTION
Move up the versioning for socialite.
Seems to work fine.
Stops installation conflicts with other packages now that socialite is at 4.0.1.